### PR TITLE
Add NPCInteraction utility

### DIFF
--- a/PlayerAgents/GameClient.NPC.cs
+++ b/PlayerAgents/GameClient.NPC.cs
@@ -1,0 +1,46 @@
+using System.Threading;
+using System.Threading.Tasks;
+using C = ClientPackets;
+using S = ServerPackets;
+
+public sealed partial class GameClient
+{
+    public async Task CallNPCAsync(uint objectId, string key)
+    {
+        if (_stream == null) return;
+        await SendAsync(new C.CallNPC { ObjectID = objectId, Key = $"[{key}]" });
+    }
+
+    public Task<S.NPCResponse> WaitForNpcResponseAsync(CancellationToken cancellationToken = default)
+    {
+        var tcs = new TaskCompletionSource<S.NPCResponse>();
+        _npcResponseTcs = tcs;
+        if (cancellationToken != default)
+            cancellationToken.Register(() => tcs.TrySetCanceled());
+        return tcs.Task;
+    }
+
+    public async Task<S.NPCResponse> WaitForLatestNpcResponseAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await WaitForNpcResponseAsync(cancellationToken).ConfigureAwait(false);
+        while (true)
+        {
+            var nextTask = WaitForNpcResponseAsync(cancellationToken);
+            var delayTask = Task.Delay(NpcResponseDebounceMs, cancellationToken);
+            var finished = await Task.WhenAny(nextTask, delayTask).ConfigureAwait(false);
+            if (finished == nextTask)
+            {
+                response = await nextTask.ConfigureAwait(false);
+                continue;
+            }
+            break;
+        }
+        return response;
+    }
+
+    private void DeliverNpcResponse(S.NPCResponse response)
+    {
+        _npcResponseTcs?.TrySetResult(response);
+        _npcResponseTcs = null;
+    }
+}

--- a/PlayerAgents/NPCInteraction.cs
+++ b/PlayerAgents/NPCInteraction.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using S = ServerPackets;
+
+public sealed record NpcButton(string Text, string Key);
+
+public sealed record NpcDialogPage(IReadOnlyList<string> Lines, IReadOnlyList<NpcButton> Buttons);
+
+public sealed class NPCInteraction
+{
+    private readonly GameClient _client;
+    private readonly uint _npcId;
+
+    public NPCInteraction(GameClient client, uint npcId)
+    {
+        _client = client;
+        _npcId = npcId;
+    }
+
+    public Task<NpcDialogPage> BeginAsync(CancellationToken cancellationToken = default)
+    {
+        return RequestPageAsync("@Main", cancellationToken);
+    }
+
+    public Task<NpcDialogPage> SelectAsync(string buttonKey, CancellationToken cancellationToken = default)
+    {
+        return RequestPageAsync(buttonKey, cancellationToken);
+    }
+
+    private async Task<NpcDialogPage> RequestPageAsync(string key, CancellationToken cancellationToken)
+    {
+        await _client.CallNPCAsync(_npcId, key);
+        var response = await _client.WaitForLatestNpcResponseAsync(cancellationToken);
+        var buttons = ParseButtons(response.Page);
+        return new NpcDialogPage(response.Page, buttons);
+    }
+
+    private static IReadOnlyList<NpcButton> ParseButtons(IEnumerable<string> lines)
+    {
+        var list = new List<NpcButton>();
+        foreach (var line in lines)
+        {
+            foreach (Match m in Regex.Matches(line, @"<([^<>]+)/(@[^>]+)>", RegexOptions.IgnoreCase))
+            {
+                list.Add(new NpcButton(m.Groups[1].Value, m.Groups[2].Value));
+            }
+        }
+        return list;
+    }
+}


### PR DESCRIPTION
## Summary
- implement `GameClient.CallNPCAsync` and `GameClient.WaitForNpcResponseAsync`
- expose NPC responses to callers
- create `NPCInteraction` helper to navigate NPC dialogs
- use `NPCInteraction` in the auto NPC scanning logic
- debounce NPC responses so forwarded pages are handled correctly

## Testing
- `dotnet build PlayerAgents/PlayerAgents.csproj -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd39c307c832085fff99505d93837