### PR TITLE
Handle NPC response timing while selling/repairing

### DIFF
--- a/PlayerAgents/GameClient.NPC.cs
+++ b/PlayerAgents/GameClient.NPC.cs
@@ -1,0 +1,67 @@
+using System.Threading;
+using System.Threading.Tasks;
+using C = ClientPackets;
+using S = ServerPackets;
+
+public sealed partial class GameClient
+{
+    public async Task CallNPCAsync(uint objectId, string key)
+    {
+        if (_stream == null) return;
+        await SendAsync(new C.CallNPC { ObjectID = objectId, Key = $"[{key}]" });
+    }
+
+    public Task<S.NPCResponse> WaitForNpcResponseAsync(CancellationToken cancellationToken = default)
+    {
+        var tcs = new TaskCompletionSource<S.NPCResponse>();
+        _npcResponseTcs = tcs;
+        if (cancellationToken != default)
+            cancellationToken.Register(() => tcs.TrySetCanceled());
+        return tcs.Task;
+    }
+
+    public async Task<S.NPCResponse> WaitForLatestNpcResponseAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await WaitForNpcResponseAsync(cancellationToken).ConfigureAwait(false);
+        while (true)
+        {
+            var nextTask = WaitForNpcResponseAsync(cancellationToken);
+            var delayTask = Task.Delay(NpcResponseDebounceMs, cancellationToken);
+            var finished = await Task.WhenAny(nextTask, delayTask).ConfigureAwait(false);
+            if (finished == nextTask)
+            {
+                response = await nextTask.ConfigureAwait(false);
+                continue;
+            }
+            break;
+        }
+        return response;
+    }
+
+    private S.NPCResponse? _queuedNpcResponse;
+    private CancellationTokenSource? _npcResponseCts;
+
+    private void DeliverNpcResponse(S.NPCResponse response)
+    {
+        _queuedNpcResponse = response;
+        _npcResponseCts?.Cancel();
+        var cts = new CancellationTokenSource();
+        _npcResponseCts = cts;
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(NpcResponseDebounceMs, cts.Token);
+                if (!cts.IsCancellationRequested && _queuedNpcResponse != null)
+                {
+                    _npcResponseTcs?.TrySetResult(_queuedNpcResponse);
+                    _npcResponseTcs = null;
+                    _queuedNpcResponse = null;
+                }
+            }
+            catch (TaskCanceledException)
+            {
+            }
+        });
+    }
+}

--- a/PlayerAgents/GameClient.Network.cs
+++ b/PlayerAgents/GameClient.Network.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Sockets;
-using System.Text.RegularExpressions;
-using System.Threading;
 using System.Threading.Tasks;
 using C = ClientPackets;
 using S = ServerPackets;
@@ -189,15 +187,10 @@ public sealed partial class GameClient
                     var entry = _npcMemory.AddNpc(on.Name, mapId, on.Location);
                     _npcEntries[on.ObjectID] = entry;
 
-                    if (_dialogNpcId.HasValue)
-                    {
-                        if (!_npcQueue.Contains(on.ObjectID))
-                            _npcQueue.Enqueue(on.ObjectID);
-                    }
-                    else
-                    {
-                        StartNpcInteraction(on.ObjectID, entry);
-                    }
+                    if (!_npcQueue.Contains(on.ObjectID))
+                        _npcQueue.Enqueue(on.ObjectID);
+                    if (!_dialogNpcId.HasValue)
+                        ProcessNextNpcInQueue();
                 }
                 break;
             case S.ObjectItem oi:
@@ -503,7 +496,7 @@ public sealed partial class GameClient
                 }
                 break;
             case S.NPCResponse nr:
-                QueueNpcResponse(nr);
+                DeliverNpcResponse(nr);
                 break;
             case S.NPCGoods goods:
                 ProcessNpcGoods(goods.List, goods.Type);
@@ -520,9 +513,14 @@ public sealed partial class GameClient
                         _npcMemory.SaveChanges();
                     }
                     if (npcSellEntry.SellItemTypes == null && npcSellEntry.CannotSellItemTypes == null)
-                        _ = Task.Run(async () => await DetermineSellTypesAsync(npcSellEntry));
+                    {
+                        _ = Task.Run(async () => await HandleNpcSellAsync(npcSellEntry));
+                    }
+                    else
+                    {
+                        ProcessNpcActionQueue();
+                    }
                 }
-                ProcessNpcActionQueue();
                 break;
             case S.NPCRepair:
             case S.NPCSRepair:
@@ -534,9 +532,14 @@ public sealed partial class GameClient
                         _npcMemory.SaveChanges();
                     }
                     if (npcRepairEntry.RepairItemTypes == null && npcRepairEntry.CannotRepairItemTypes == null)
-                        _ = Task.Run(async () => await DetermineRepairTypesAsync(npcRepairEntry));
+                    {
+                        _ = Task.Run(async () => await HandleNpcRepairAsync(npcRepairEntry));
+                    }
+                    else
+                    {
+                        ProcessNpcActionQueue();
+                    }
                 }
-                ProcessNpcActionQueue();
                 break;
             case S.SellItem sell:
                 if (_pendingSellChecks.TryGetValue(sell.UniqueID, out var infoSell))
@@ -549,6 +552,38 @@ public sealed partial class GameClient
                             infoSell.entry.SellItemTypes.Add(infoSell.type);
                             _npcMemory.SaveChanges();
                         }
+                        if (_inventory != null)
+                        {
+                            int idx = Array.FindIndex(_inventory, x => x != null && x.UniqueID == sell.UniqueID);
+                            if (idx >= 0)
+                            {
+                                var it = _inventory[idx];
+                                if (it != null)
+                                {
+                                    if (it.Count <= sell.Count)
+                                        _inventory[idx] = null;
+                                    else
+                                        it.Count -= sell.Count;
+                                }
+                            }
+                        }
+                        if (_equipment != null)
+                        {
+                            int idx = Array.FindIndex(_equipment, x => x != null && x.UniqueID == sell.UniqueID);
+                            if (idx >= 0)
+                            {
+                                var it = _equipment[idx];
+                                if (it != null)
+                                {
+                                    if (it.Count <= sell.Count)
+                                        _equipment[idx] = null;
+                                    else
+                                        it.Count -= sell.Count;
+                                }
+                            }
+                        }
+                        if (_lastPickedItem != null && _lastPickedItem.UniqueID == sell.UniqueID)
+                            _lastPickedItem = null;
                     }
                     else
                     {
@@ -618,104 +653,6 @@ public sealed partial class GameClient
         }
     }
 
-    private void QueueNpcResponse(S.NPCResponse nr)
-    {
-        _queuedNpcResponse = nr;
-        _npcResponseCts?.Cancel();
-        var cts = new CancellationTokenSource();
-        _npcResponseCts = cts;
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                await Task.Delay(NpcResponseDebounceMs, cts.Token);
-                if (!cts.IsCancellationRequested && _queuedNpcResponse != null)
-                {
-                    ProcessNpcResponse(_queuedNpcResponse);
-                    _queuedNpcResponse = null;
-                }
-            }
-            catch (TaskCanceledException)
-            {
-            }
-        });
-    }
-
-    private void ProcessNpcResponse(S.NPCResponse nr)
-    {
-        if (_dialogNpcId.HasValue && _npcEntries.TryGetValue(_dialogNpcId.Value, out var npcRespEntry))
-        {
-            string text = string.Join(" ", nr.Page);
-            var matches = Regex.Matches(text, @"<[^<>]*/(@[^>]+)>");
-            var keyList = matches.Cast<Match>().Select(m => m.Groups[1].Value).ToList();
-            var keys = new HashSet<string>(keyList.Select(k => k.ToUpper()));
-
-            bool changed = false;
-
-            bool hasBuy = keys.Overlaps(new[] { "@BUY", "@BUYSELL", "@BUYNEW", "@BUYSELLNEW", "@PEARLBUY" });
-            bool hasSell = keys.Overlaps(new[] { "@SELL", "@BUYSELL", "@BUYSELLNEW" });
-            bool hasRepair = keys.Overlaps(new[] { "@REPAIR", "@SREPAIR" });
-
-            if (hasBuy)
-            {
-                if (!npcRespEntry.CanBuy)
-                {
-                    npcRespEntry.CanBuy = true;
-                    changed = true;
-                }
-                if (npcRespEntry.BuyItemIndexes == null)
-                {
-                    string[] buyKeys = { "@BUYSELLNEW", "@BUYSELL", "@BUYNEW", "@PEARLBUY", "@BUY" };
-                    string key = keyList.FirstOrDefault(k => buyKeys.Contains(k.ToUpper())) ?? "@BUY";
-                    if (!key.Equals("@BUYBACK", StringComparison.OrdinalIgnoreCase))
-                        _npcActionKeys.Enqueue(key);
-                    else
-                        _skipNextGoods = true;
-                }
-            }
-
-            if (hasSell)
-            {
-                if (!npcRespEntry.CanSell)
-                {
-                    npcRespEntry.CanSell = true;
-                    changed = true;
-                }
-                if (npcRespEntry.SellItemTypes == null && npcRespEntry.CannotSellItemTypes == null)
-                {
-                    string[] sellKeys = { "@BUYSELLNEW", "@BUYSELL", "@SELL" };
-                    string key = keyList.FirstOrDefault(k => sellKeys.Contains(k.ToUpper())) ?? "@SELL";
-                    if (!key.Equals("@BUYBACK", StringComparison.OrdinalIgnoreCase))
-                        _npcActionKeys.Enqueue(key);
-                    else
-                        _skipNextGoods = true;
-                }
-            }
-
-            if (hasRepair)
-            {
-                if (!npcRespEntry.CanRepair)
-                {
-                    npcRespEntry.CanRepair = true;
-                    changed = true;
-                }
-                if (npcRespEntry.RepairItemTypes == null && npcRespEntry.CannotRepairItemTypes == null)
-                {
-                    string[] repairKeys = { "@SREPAIR", "@REPAIR" };
-                    string key = keyList.FirstOrDefault(k => repairKeys.Contains(k.ToUpper())) ?? "@REPAIR";
-                    if (!key.Equals("@BUYBACK", StringComparison.OrdinalIgnoreCase))
-                        _npcActionKeys.Enqueue(key);
-                    else
-                        _skipNextGoods = true;
-                }
-            }
-
-            if (changed)
-                _npcMemory.SaveChanges();
-
-            ProcessNpcActionQueue();
-        }
-    }
 
     private void HandleTradeFailChat(string text)
     {

--- a/PlayerAgents/GameClient.cs
+++ b/PlayerAgents/GameClient.cs
@@ -72,11 +72,12 @@ public sealed partial class GameClient
     private bool _skipNextGoods;
     public bool IsProcessingNpc => _dialogNpcId.HasValue;
 
+    private NPCInteraction? _npcInteraction;
+
     private readonly Dictionary<ulong, (NpcEntry entry, ItemType type)> _pendingSellChecks = new();
     private readonly Dictionary<ulong, (NpcEntry entry, ItemType type)> _pendingRepairChecks = new();
 
-    private S.NPCResponse? _queuedNpcResponse;
-    private CancellationTokenSource? _npcResponseCts;
+    private TaskCompletionSource<S.NPCResponse>? _npcResponseTcs;
     private const int NpcResponseDebounceMs = 100;
 
 
@@ -326,9 +327,18 @@ public sealed partial class GameClient
         {
             if (item == null || item.Info == null) continue;
             if (seen.Contains(item.Info.Type)) continue;
+            seen.Add(item.Info.Type);
             _pendingSellChecks[item.UniqueID] = (entry, item.Info.Type);
             Console.WriteLine($"I am selling {item.Info.FriendlyName} to {entry.Name}");
             await SendAsync(new C.SellItem { UniqueID = item.UniqueID, Count = 1 });
+            try
+            {
+                using var cts = new CancellationTokenSource(2000);
+                await WaitForLatestNpcResponseAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+            }
             await Task.Delay(100);
         }
     }
@@ -347,8 +357,32 @@ public sealed partial class GameClient
             _pendingRepairChecks[item.UniqueID] = (entry, item.Info.Type);
             Console.WriteLine($"I am repairing {item.Info.FriendlyName} at {entry.Name}");
             await SendAsync(new C.RepairItem { UniqueID = item.UniqueID });
+            try
+            {
+                using var cts = new CancellationTokenSource(2000);
+                await WaitForLatestNpcResponseAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+            }
             await Task.Delay(100);
         }
+    }
+
+    private async Task HandleNpcSellAsync(NpcEntry entry)
+    {
+        _processingNpcAction = true;
+        await DetermineSellTypesAsync(entry);
+        _processingNpcAction = false;
+        ProcessNpcActionQueue();
+    }
+
+    private async Task HandleNpcRepairAsync(NpcEntry entry)
+    {
+        _processingNpcAction = true;
+        await DetermineRepairTypesAsync(entry);
+        _processingNpcAction = false;
+        ProcessNpcActionQueue();
     }
 
     private void ProcessNpcGoods(IEnumerable<UserItem> goods, PanelType type)
@@ -387,6 +421,7 @@ public sealed partial class GameClient
             !_processingNpcAction)
         {
             _dialogNpcId = null;
+            _npcInteraction = null;
             ProcessNextNpcInQueue();
         }
     }
@@ -406,7 +441,7 @@ public sealed partial class GameClient
 
     private async void ProcessNpcActionQueue()
     {
-        if (_processingNpcAction || !_dialogNpcId.HasValue) return;
+        if (_processingNpcAction || !_dialogNpcId.HasValue || _npcInteraction == null) return;
         if (_pendingSellChecks.Count > 0 || _pendingRepairChecks.Count > 0) return;
 
         if (_npcActionKeys.Count == 0)
@@ -422,25 +457,112 @@ public sealed partial class GameClient
             _processingNpcAction = false;
             return;
         }
-        var npcId = _dialogNpcId.Value;
-        await SendAsync(new C.CallNPC { ObjectID = npcId, Key = "[@Main]" });
-        await Task.Delay(50);
-        if (!_dialogNpcId.HasValue || _dialogNpcId.Value != npcId)
+        var page = await _npcInteraction.SelectFromMainAsync(key);
+        if (!_dialogNpcId.HasValue)
         {
             _processingNpcAction = false;
             return;
         }
-        await SendAsync(new C.CallNPC { ObjectID = npcId, Key = $"[{key}]" });
+        if (_npcEntries.TryGetValue(_dialogNpcId.Value, out var entry))
+            HandleNpcDialogPage(page, entry);
+        _processingNpcAction = false;
     }
 
-    private void StartNpcInteraction(uint id, NpcEntry entry)
+    private async void StartNpcInteraction(uint id, NpcEntry entry)
     {
         _dialogNpcId = id;
         _npcInteractionStart = DateTime.UtcNow;
         _npcActionKeys.Clear();
         _processingNpcAction = false;
         Console.WriteLine($"I am speaking with NPC {entry.Name}");
-        _ = SendAsync(new C.CallNPC { ObjectID = id, Key = "[@Main]" });
+        _npcInteraction = new NPCInteraction(this, id);
+        var page = await _npcInteraction.BeginAsync();
+        HandleNpcDialogPage(page, entry);
+    }
+
+    private void HandleNpcDialogPage(NpcDialogPage page, NpcEntry entry)
+    {
+        var keyList = page.Buttons.Select(b => b.Key).ToList();
+        var keys = new HashSet<string>(keyList.Select(k => k.ToUpper()));
+
+        bool changed = false;
+
+        bool hasBuy = keys.Overlaps(new[] { "@BUY", "@BUYSELL", "@BUYNEW", "@BUYSELLNEW", "@PEARLBUY" });
+        bool hasSell = keys.Overlaps(new[] { "@SELL", "@BUYSELL", "@BUYSELLNEW" });
+        bool hasRepair = keys.Overlaps(new[] { "@REPAIR", "@SREPAIR" });
+
+        string? buyKey = null;
+        string? sellKey = null;
+        string? repairKey = null;
+
+        if (hasBuy)
+        {
+            if (!entry.CanBuy)
+            {
+                entry.CanBuy = true;
+                changed = true;
+            }
+            if (entry.BuyItemIndexes == null)
+            {
+                string[] buyKeys = { "@BUYSELLNEW", "@BUYSELL", "@BUYNEW", "@PEARLBUY", "@BUY" };
+                buyKey = keyList.FirstOrDefault(k => buyKeys.Contains(k.ToUpper())) ?? "@BUY";
+                if (buyKey.Equals("@BUYBACK", StringComparison.OrdinalIgnoreCase))
+                {
+                    _skipNextGoods = true;
+                    buyKey = null;
+                }
+            }
+        }
+
+        if (hasSell)
+        {
+            if (!entry.CanSell)
+            {
+                entry.CanSell = true;
+                changed = true;
+            }
+            if (entry.SellItemTypes == null && entry.CannotSellItemTypes == null)
+            {
+                string[] sellKeys = { "@BUYSELLNEW", "@BUYSELL", "@SELL" };
+                sellKey = keyList.FirstOrDefault(k => sellKeys.Contains(k.ToUpper())) ?? "@SELL";
+                if (sellKey.Equals("@BUYBACK", StringComparison.OrdinalIgnoreCase))
+                {
+                    _skipNextGoods = true;
+                    sellKey = null;
+                }
+            }
+        }
+
+        if (hasRepair)
+        {
+            if (!entry.CanRepair)
+            {
+                entry.CanRepair = true;
+                changed = true;
+            }
+            if (entry.RepairItemTypes == null && entry.CannotRepairItemTypes == null)
+            {
+                string[] repairKeys = { "@SREPAIR", "@REPAIR" };
+                repairKey = keyList.FirstOrDefault(k => repairKeys.Contains(k.ToUpper())) ?? "@REPAIR";
+                if (repairKey.Equals("@BUYBACK", StringComparison.OrdinalIgnoreCase))
+                {
+                    _skipNextGoods = true;
+                    repairKey = null;
+                }
+            }
+        }
+
+        if (buyKey != null)
+            _npcActionKeys.Enqueue(buyKey);
+        if (sellKey != null)
+            _npcActionKeys.Enqueue(sellKey);
+        if (repairKey != null)
+            _npcActionKeys.Enqueue(repairKey);
+
+        if (changed)
+            _npcMemory.SaveChanges();
+
+        ProcessNpcActionQueue();
     }
 
     private void CheckNpcInteractionTimeout()

--- a/PlayerAgents/NPCInteraction.cs
+++ b/PlayerAgents/NPCInteraction.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using S = ServerPackets;
+
+public sealed record NpcButton(string Text, string Key);
+
+public sealed record NpcDialogPage(IReadOnlyList<string> Lines, IReadOnlyList<NpcButton> Buttons);
+
+public sealed class NPCInteraction
+{
+    private readonly GameClient _client;
+    private readonly uint _npcId;
+
+    public NPCInteraction(GameClient client, uint npcId)
+    {
+        _client = client;
+        _npcId = npcId;
+    }
+
+    public Task<NpcDialogPage> BeginAsync(CancellationToken cancellationToken = default)
+    {
+        return RequestPageAsync("@Main", cancellationToken);
+    }
+
+    public Task<NpcDialogPage> SelectAsync(string buttonKey, CancellationToken cancellationToken = default)
+    {
+        return RequestPageAsync(buttonKey, cancellationToken);
+    }
+
+    public async Task<NpcDialogPage> SelectFromMainAsync(string buttonKey, CancellationToken cancellationToken = default)
+    {
+        await RequestPageAsync("@Main", cancellationToken);
+        await Task.Delay(50, cancellationToken);
+        return await RequestPageAsync(buttonKey, cancellationToken);
+    }
+
+    private async Task<NpcDialogPage> RequestPageAsync(string key, CancellationToken cancellationToken)
+    {
+        await _client.CallNPCAsync(_npcId, key);
+        var response = await _client.WaitForLatestNpcResponseAsync(cancellationToken);
+        var buttons = ParseButtons(response.Page);
+        return new NpcDialogPage(response.Page, buttons);
+    }
+
+    private static IReadOnlyList<NpcButton> ParseButtons(IEnumerable<string> lines)
+    {
+        var list = new List<NpcButton>();
+        foreach (var line in lines)
+        {
+            foreach (Match m in Regex.Matches(line, @"<([^<>]+)/(@[^>]+)>", RegexOptions.IgnoreCase))
+            {
+                list.Add(new NpcButton(m.Groups[1].Value, m.Groups[2].Value));
+            }
+        }
+        return list;
+    }
+}


### PR DESCRIPTION
## Summary
- wait for a debounced NPC response after each SellItem and RepairItem request
- ensure sequential processing of buy, sell, and repair actions

## Testing
- `dotnet build PlayerAgents/PlayerAgents.csproj -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd39c307c832085fff99505d93837